### PR TITLE
Enable useful in libvirt 2.0.0

### DIFF
--- a/host/negotiator_host/cli.py
+++ b/host/negotiator_host/cli.py
@@ -39,7 +39,11 @@ Supported options:
 
   -v, --verbose
 
-    Make more noise (enables debugging).
+    Make more noise verbose infomation.
+
+  -D, --debug
+
+    Enable debugging mode.
 
   -q, --quiet
 
@@ -78,9 +82,9 @@ def main():
     actions = []
     context = Context()
     try:
-        options, arguments = getopt.getopt(sys.argv[1:], 'gce:t:dvqh', [
+        options, arguments = getopt.getopt(sys.argv[1:], 'gce:t:dvqhD', [
             'list-guests', 'list-commands', 'execute=', 'timeout=', 'daemon',
-            'verbose', 'quiet', 'help'
+            'verbose', 'quiet', 'help', 'debug'
         ])
         for option, value in options:
             if option in ('-g', '--list-guests'):
@@ -101,6 +105,8 @@ def main():
                 coloredlogs.increase_verbosity()
             elif option in ('-q', '--quiet'):
                 coloredlogs.decrease_verbosity()
+            elif option in ('-D', '--debug'):
+                coloredlogs.set_level(level='DEBUG')
             elif option in ('-h', '--help'):
                 usage()
                 sys.exit(0)


### PR DESCRIPTION
When run in CentOS 7.3 with libvirt 2.0.0 will not work. Because it has new directory/file naming scheme for channels:
```
/var/lib/libvirt/qemu/channel/target/domain-DOMAIN_ID-GUEST_NAME/negotiator-guest-to-host.0
```